### PR TITLE
Fix power signal

### DIFF
--- a/arch/arm/boot/dts/imx7d-var-som.dtsi
+++ b/arch/arm/boot/dts/imx7d-var-som.dtsi
@@ -123,22 +123,6 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&pinctrl_gpio_leds>;
 
-		red {
-			label = "Red";
-			gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
-		};
-
-		green {
-			label = "Green";
-			gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
-			default-state = "on";
-		};
-
-		blue {
-			label = "Blue";
-			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
-		};
-
 		power {
 			label = "Power";
 			gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
@@ -407,8 +391,6 @@
 				MX7D_PAD_SD2_RESET_B__GPIO5_IO11	0x59  /* ethphy0 reset */
 				MX7D_PAD_UART2_TX_DATA__GPIO4_IO3	0x59  /* ethphy1 reset */
 				MX7D_PAD_GPIO1_IO10__GPIO1_IO10		0x0C  /* SOM_SIG1 */
-				MX7D_PAD_GPIO1_IO11__GPIO1_IO11		0x0C  /* SOM_SIG2 */
-				MX7D_PAD_GPIO1_IO12__GPIO1_IO12		0x0C  /* SOM_SIG3 */
 				MX7D_PAD_GPIO1_IO13__GPIO1_IO13		0x0C  /* EN_3V3_HC_SOM, pulled down externally */
 				MX7D_PAD_SD1_WP__CCM_CLKO2		0xb0  /* camera clock */
 			>;

--- a/arch/arm/boot/dts/imx7d-var-som.dtsi
+++ b/arch/arm/boot/dts/imx7d-var-som.dtsi
@@ -116,23 +116,6 @@
 			status = "okay";
 		};
 
-		reg_hsic_hub_pwr_on: reg_hsic_hub_pwr_on {
-			compatible = "regulator-fixed";
-			regulator-name = "hsic_hub_pwr_on";
-			gpio = <&gpio1 10 GPIO_ACTIVE_HIGH>;
-			enable-active-high;
-			regulator-always-on;
-			status = "okay";
-		};
-
-		reg_hsic_hub_connect: reg_hsic_hub_connect {
-			compatible = "regulator-fixed";
-			regulator-name = "reg_hsic_hub_connect";
-			gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
-			enable-active-high;
-			regulator-always-on;
-			status = "okay";
-		};
 	};
 
 	gpio-leds {
@@ -154,6 +137,12 @@
 		blue {
 			label = "Blue";
 			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
+		};
+
+		power {
+			label = "Power";
+			gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
 		};
 	};
 };
@@ -823,11 +812,6 @@
 	assigned-clocks = <&clks IMX7D_UART6_ROOT_SRC>;
 	assigned-clock-parents = <&clks IMX7D_PLL_SYS_MAIN_240M_CLK>;
 	status = "okay";
-};
-
-&usbh {
-	status = "okay";
-	vbus-supply = <&reg_hsic_hub_pwr_on>;
 };
 
 &usbotg1 {


### PR DESCRIPTION
This will make SOM_SIG1 turn high when linux is booted and low when the system is halted, allowing sailsense/embedded_fw#210 to be fixed.

Also removes some more Variscite devboard specific constructs and old leds and iomux configuration from the KDT.

This uses a workaround using the leds-gpio driver since the gpio-poweroff driver does not seem to work, probably due to some BSP specific reasons I failed to debug. Will ask Variscite about this.